### PR TITLE
Restore build output script

### DIFF
--- a/build-output.js
+++ b/build-output.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const outputDir = path.join('.vercel', 'output');
+const staticDir = path.join(outputDir, 'static');
+const functionsDir = path.join(outputDir, 'functions');
+const configPath = path.join(outputDir, 'config.json');
+
+fs.mkdirSync(staticDir, { recursive: true });
+fs.mkdirSync(functionsDir, { recursive: true });
+
+const routes = [];
+
+// Copy static knowledge and instruction files
+if (fs.existsSync('static')) {
+  for (const file of fs.readdirSync('static')) {
+    if (file.endsWith('.txt')) {
+      fs.copyFileSync(path.join('static', file), path.join(staticDir, file));
+    }
+  }
+}
+
+// Create a function for each Python file
+for (const file of fs.readdirSync('api')) {
+  if (!file.endsWith('.py')) continue;
+  const name = path.basename(file, '.py');
+  const funcDir = path.join(functionsDir, `api/${name}.func`);
+  fs.mkdirSync(funcDir, { recursive: true });
+  fs.copyFileSync(path.join('api', file), path.join(funcDir, 'index.py'));
+
+  // copy shared requirements so the Python runtime installs dependencies
+  if (fs.existsSync('requirements.txt')) {
+    fs.copyFileSync('requirements.txt', path.join(funcDir, 'requirements.txt'));
+  }
+  const config = { runtime: 'python3.11', handler: 'index.py' };
+  fs.writeFileSync(path.join(funcDir, '.vc-config.json'), JSON.stringify(config, null, 2));
+  routes.push({ src: `/api/${name}`, dest: `functions/api/${name}.func` });
+}
+
+fs.writeFileSync(configPath, JSON.stringify({ version: 3, routes }, null, 2));

--- a/build-output.js
+++ b/build-output.js
@@ -9,7 +9,7 @@ const configPath = path.join(outputDir, 'config.json');
 fs.mkdirSync(staticDir, { recursive: true });
 fs.mkdirSync(functionsDir, { recursive: true });
 
-const routes = [{ handle: 'filesystem' }];
+const routes = [];
 
 // Copy static knowledge and instruction files
 if (fs.existsSync('static')) {
@@ -50,5 +50,9 @@ if (fs.existsSync(maintSrc)) {
   fs.writeFileSync(path.join(maintDir, '.vc-config.json'), JSON.stringify(config, null, 2));
   routes.push({ src: '/internal/(.*)', dest: 'functions/api/maintenance/[task].func' });
 }
+
+// Static text file route and filesystem handler
+routes.push({ src: '/static/(.*)', dest: 'static/$1' });
+routes.push({ handle: 'filesystem' });
 
 fs.writeFileSync(configPath, JSON.stringify({ version: 3, routes }, null, 2));

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "dependencies": {
     "vercel": "^32.0.1"
+  },
+  "scripts": {
+    "vercel-build": "node build-output.js"
   }
 }


### PR DESCRIPTION
## Summary
- rebuild `build-output.js` to copy static files and Python functions
- run script via `vercel-build` in `package.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_6865be60df288323ac00543c3e92034a