### PR TITLE
Fix static asset serving in build output

### DIFF
--- a/build-output.js
+++ b/build-output.js
@@ -9,7 +9,8 @@ const configPath = path.join(outputDir, 'config.json');
 fs.mkdirSync(staticDir, { recursive: true });
 fs.mkdirSync(functionsDir, { recursive: true });
 
-const routes = [];
+// Ensure static assets are served before dynamic routes
+const routes = [{ handle: 'filesystem' }];
 
 // Copy static knowledge and instruction files
 if (fs.existsSync('static')) {

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,5 @@
 {
-  "version": 2,
-  "builds": [
-    { "src": "api/**/*.py", "use": "@vercel/python" }
-  ],
-  "routes": [
-    { "src": "/static/(.*)", "dest": "static/$1" },
-    { "src": "/internal/(.*)", "dest": "api/maintenance/[task].py" },
-    { "src": "/api/(.*)",     "dest": "api/$1.py" }
-  ]
+  "framework": "other",
+  "buildCommand": "npm run vercel-build",
+  "outputDirectory": ".vercel/output"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "framework": "other",
+  "framework": null,
   "buildCommand": "npm run vercel-build",
   "outputDirectory": ".vercel/output"
 }


### PR DESCRIPTION
## Summary
- ensure static assets are served before dynamic functions when building Vercel output

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ConnectionError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6865cc7c7130832393cfc730d0553939